### PR TITLE
feat: reuse code panel width after switch demo page

### DIFF
--- a/theme/default/src/demo.js
+++ b/theme/default/src/demo.js
@@ -109,6 +109,35 @@ $(window).resize(resizePreview);
 const $detail = $('.detail');
 const $codePanel = $('.code-panel');
 const $menu = $('.menu');
+
+/**
+ * 设置代码编辑区的宽度
+ * @param codePanelWidth
+ */
+function setCodePanelWidth(codePanelWidth) {
+    $codePanel.css('flex', `0 0 ${codePanelWidth < 300 ? 300 : codePanelWidth}px`);
+}
+
+/**
+ * 缓存代码编辑区的宽度到本地存储中，方便下次刷新页面后复用，以提升体验
+ * @param codePanelWidth
+ */
+function cacheCodePanelWidth(codePanelWidth) {
+    localStorage.setItem('codePanelWidth', codePanelWidth);
+}
+
+/**
+ * 获取本地存储中的代码编辑区的宽度
+ * @returns {string | null | number}
+ */
+function getCacheCodePanelWidth() {
+    const defaultWidth = 432;
+    return localStorage.getItem('codePanelWidth') || defaultWidth;
+}
+
+const codePanelWidthFromCache = getCacheCodePanelWidth();
+setCodePanelWidth(codePanelWidthFromCache);
+
 $detail.resizable({
     handleSelector: '#resize-handler',
     resizeWidthFrom: 'right',
@@ -124,6 +153,8 @@ $detail.resizable({
             newWidth = 486;
         }
         const codePanelWidth = winWidth - $menu.width() - newWidth;
+        setCodePanelWidth(codePanelWidth);
+        cacheCodePanelWidth(codePanelWidth);
         $codePanel.css('flex', `0 0 ${codePanelWidth < 300 ? 300 : codePanelWidth}px`);
     },
     onDragEnd() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

拖拽时缓存代码编辑区的宽度到本地存储中，方便下次刷新页面后复用，以提升体验，如下图所示：
![reuse-codepanelwidth-after-refresh](https://user-images.githubusercontent.com/2217416/44447884-37302f80-a61c-11e8-9df1-435e038782ab.gif)


