### PR TITLE
fix: legend blocked problem

### DIFF
--- a/site/zh-cn/g2/3.x/tutorial/data-set.md
+++ b/site/zh-cn/g2/3.x/tutorial/data-set.md
@@ -316,6 +316,7 @@ $.getJSON('/assets/data/population-by-age.json', function(data) {
         id: 'c1',
         forceFit: true,
         height: 400,
+        padding: [40, 'auto', 'auto', 'auto']
     });
     c1.source(dvForAll);
     c1.legend({


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
自动计算的 `top-padding` 似乎不对, 导致 `legend` 被挡住了, 我暂时直接把 `padding-top` 改成40 了.

不过 root cause 应该还是 `padding` 自动计算不太对, 这部分代码我暂时不熟, 之后有机会熟悉了再帮忙改吧.
![selection_319](https://user-images.githubusercontent.com/10973821/44573668-d0487d00-a7b9-11e8-84aa-45fdbf83121c.png)
