### PR TITLE
fix hot keywords and site map

### DIFF
--- a/site/zh-cn/data.js
+++ b/site/zh-cn/data.js
@@ -168,10 +168,11 @@ const data = {
         '${products.vis}',
         {
             name: '更多产品',
+            href: 'https://xcloud.alipay.com/',
             external: true,
             links: {
-                antd: { text: 'Ant Design', href: 'https://ant.design/index-cn', description: '蚂蚁 UI 设计体系' },
-                egg:  { text: 'Egg', href: 'https://eggjs.org/', description: '企业级 Node Web 开发框架' },
+                antd: { text: 'Ant Design', href: 'https://ant.design/index-cn', description: 'UI 设计体系' },
+                egg:  { text: 'Egg', href: 'https://eggjs.org/', description: 'Node Web开发框架' },
             }
         },
     ],

--- a/theme/default/src/hot-keywords.js
+++ b/theme/default/src/hot-keywords.js
@@ -1,20 +1,26 @@
 module.exports = {
-  g2: [
-    { title: 'G2 FAQ', keyword: '多 y 轴图表', href: '/zh-cn/g2/3.x/tutorial/faq.html#_%E5%A6%82%E4%BD%95%E7%BB%98%E5%88%B6%E5%A4%9A-y-%E8%BD%B4%E5%9B%BE%E8%A1%A8' },
-    { title: 'G2 Tooltip', keyword: 'Tooltip 提示信息', href: '/zh-cn/g2/3.x/tutorial/tooltip.html' },
-    { title: 'G2 Guide', keyword: 'Guide 辅助元素', href: '/zh-cn/g2/3.x/tutorial/guide.html' },
-    { title: 'G2 Renderers', keyword: 'SVG', href: '/zh-cn/g2/3.x/tutorial/renderers.html#' },
+  G2: [
+    { title: 'G2 Line', keyword: '折线图', href: '/zh-cn/g2/3.x/demo/line/basic.html' },
+    { title: 'G2 Column', keyword: '柱状图', href: '/zh-cn/g2/3.x/demo/column/basic-column.html' },
+    { title: 'G2 Rose', keyword: '玫瑰图', href: '/zh-cn/g2/3.x/demo/pie/color-rose.html' },
+    { title: 'G2 Heatmap', keyword: '热力图', href: '/zh-cn/g2/3.x/demo/heatmap/basic.html' },
   ],
-  f2: [
-    { title: 'F2 Interaction', keyword: '交互行为', href: '/zh-cn/f2/3.x/api/interaction.html' },
-    { title: 'F2 MiniProgram', keyword: '小程序', href: '/zh-cn/f2/3.x/tutorial/miniprogram.html' },
-    { title: 'F2 Axis', keyword: 'Axis 坐标轴', href: '/zh-cn/f2/3.x/api/axis.html' },
-    { title: 'F2 Legend', keyword: 'Legend 图例', href: '/zh-cn/f2/3.x/api/legend.html' },
+  G6: [
+    { title: 'G6 Tree', keyword: '树图', href: '/zh-cn/g6/3.x/demo/tree/tree-compact-box.html' },
+    { title: 'G6 Sankey', keyword: '桑基图', href: '/zh-cn/g6/3.x/demo/flow/sankey.html' },
+    { title: 'G6 Force', keyword: '力导图', href: '/zh-cn/g6/3.x/demo/net/base-force.html' },
+    { title: 'G6 Animate', keyword: '自定义动画', href: '/zh-cn/g6/3.x/demo/scatter/position-animate.html' },
   ],
-  g6: [
-    { title: 'G6 Layout', keyword: 'Layouts', href: '/zh-cn/g6/1.x/api/layouts.html' },
-    { title: 'G6 Interaction', keyword: '自定义交互', href: '/zh-cn/g6/1.x/tutorial/custom-interaction.html' },
-    { title: 'G6 Shape', keyword: '自定义图项', href: '/zh-cn/g6/1.x/tutorial/custom-shape.html' },
-    { title: 'G6 Anchor', keyword: '锚点详解', href: '/zh-cn/g6/1.x/tutorial/detail-anchor.html' },
+  F2: [
+    { title: 'F2 Gallery', keyword: 'Gallery', href: '/zh-cn/f2/3.x/demo/index.html' },
+    { title: 'F2 Interaction', keyword: '图表交互', href: '/zh-cn/f2/3.x/demo/index.html#_图表交互' },
+    { title: 'F2 Radar', keyword: '雷达图', href: '/zh-cn/f2/3.x/demo/index.html#_雷达图' },
+    { title: 'F2 Component', keyword: '功能组件', href: '/zh-cn/f2/3.x/demo/index.html#_功能组件' },
+  ],
+  L7: [
+    { title: 'L7 Bubble', keyword: '气泡图', href: '/zh-cn/l7/1.x/demo/point/pointcircle.html' },
+    { title: 'L7 One Belt One Road', keyword: '一带一路', href: '/zh-cn/l7/1.x/demo/line/onebeltoneroad.html' },
+    { title: 'L7 City', keyword: '城市渲染', href: '/zh-cn/l7/1.x/demo/polygon/city.html' },
+    { title: 'L7 Legend', keyword: '栅格数据', href: '/zh-cn/l7/1.x/demo/raster/dem.html' },
   ],
 };

--- a/theme/default/src/less/col-5ths.less
+++ b/theme/default/src/less/col-5ths.less
@@ -18,7 +18,7 @@
 
 @media (min-width: 768px) {
   .col-md-5ths {
-    flex: 0 0 20%;
-    max-width: 20%;
+    flex: 0 0 16.6%;
+    max-width: 16.6%;
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
1. Due to documents moving to yuque.com, hot keywords cannot work normally. Fix this issue by changing hot keywords.
2. Fix site map. In current version, _more product_ falls on the next line and blocks some links of G2.